### PR TITLE
[RING-45] Render 서버 유지를 위한 ping 워크플로 추가

### DIFF
--- a/.github/workflows/ping.yaml
+++ b/.github/workflows/ping.yaml
@@ -1,0 +1,15 @@
+name: Keep Render Alive (${{ secrets.PING_ENABLED == 'true' && 'ENABLED' || 'DISABLED' }})
+
+on:
+  schedule:
+    - cron: '*/14 23-15 * * *'  # KST 08:00 ~ 24:00
+  workflow_dispatch:
+
+jobs:
+  ping:
+    if: ${{ secrets.PING_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ping Render Health Check
+        run: curl -m 10 "${{ secrets.RENDER_PING_URL }}"

--- a/.github/workflows/ping.yaml
+++ b/.github/workflows/ping.yaml
@@ -1,15 +1,22 @@
-name: Keep Render Alive (${{ secrets.PING_ENABLED == 'true' && 'ENABLED' || 'DISABLED' }})
+name: Keep Render Alive (${{ vars.pingEnabled == 'true' && 'ENABLED' || 'DISABLED' }})
+
+vars:
+  pingEnabled: ${{ secrets.PING_ENABLED }}
 
 on:
   schedule:
-    - cron: '*/14 23-15 * * *'  # KST 08:00 ~ 24:00
+    - cron: '*/14 23 * * *'     # UTC 23시 ⇒ KST 08시
+    - cron: '*/14 0-15 * * *'   # UTC 00~15시 ⇒ KST 09~24시
   workflow_dispatch:
 
 jobs:
   ping:
-    if: ${{ secrets.PING_ENABLED == 'true' }}
+    env:
+      PING_ENABLED:    ${{ secrets.PING_ENABLED }}
+      RENDER_PING_URL: ${{ secrets.RENDER_PING_URL }}
+    if: env.PING_ENABLED == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: Ping Render Health Check
-        run: curl -m 10 "${{ secrets.RENDER_PING_URL }}"
+        run: curl -m 10 "${{ env.RENDER_PING_URL }}"

--- a/.github/workflows/ping.yaml
+++ b/.github/workflows/ping.yaml
@@ -1,7 +1,4 @@
-name: Keep Render Alive (${{ vars.pingEnabled == 'true' && 'ENABLED' || 'DISABLED' }})
-
-vars:
-  pingEnabled: ${{ secrets.PING_ENABLED }}
+name: Keep Render Alive
 
 on:
   schedule:

--- a/.github/workflows/ping.yaml
+++ b/.github/workflows/ping.yaml
@@ -8,12 +8,9 @@ on:
 
 jobs:
   ping:
-    env:
-      PING_ENABLED:    ${{ secrets.PING_ENABLED }}
-      RENDER_PING_URL: ${{ secrets.RENDER_PING_URL }}
-    if: env.PING_ENABLED == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: Ping Render Health Check
-        run: curl -m 10 "${{ env.RENDER_PING_URL }}"
+        if: ${{ secrets.PING_ENABLED == 'true' }}
+        run: curl -m 10 "${{ secrets.RENDER_PING_URL }}"


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 일정 간격으로 Render에 ping을 보내 서버를 깨우도록 설정
- KST 기준 08:00~24:00 동안 14분마다 실행
- 워크플로는 `PING_ENABLED` 시크릿이 true일 경우에만 작동
- 서버 다운타임을 방지하기 위한 무료 tier 유지 전략

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- 새로운 GitHub Actions 워크플로우가 추가되어, 일정 시간마다 서비스 상태 확인을 위한 자동 핑(ping)이 실행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->