### PR TITLE
[RING-58] 배포 오류를 야기한 인증이 필요 없는 api 접근 불가 문제 해결

### DIFF
--- a/backend/src/main/java/com/airing/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/airing/backend/config/SecurityConfig.java
@@ -53,7 +53,16 @@ public class SecurityConfig {
                                 "/api/auth/reissue",
                                 "/api/auth/logout",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**").permitAll()
+                                "/v3/api-docs/**",
+                                "/health-check",
+                                "/",
+                                "/index.html",
+                                "/favicon.ico",
+                                "/css/**",
+                                "/js/**",
+                                "/images/**",
+                                "/static/**"
+                        ).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/airing/backend/controller/IndexController.java
+++ b/backend/src/main/java/com/airing/backend/controller/IndexController.java
@@ -19,11 +19,6 @@ public class IndexController {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @GetMapping({"", "/"})
-    public String index() {
-        return "index";
-    }
-
     @GetMapping("/user")
     public @ResponseBody String user() {
         return "user";

--- a/backend/src/test/java/com/airing/backend/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/airing/backend/HealthCheckControllerTest.java
@@ -1,0 +1,28 @@
+package com.airing.backend;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HealthCheckControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("헬스 체크 API는 status=ok를 반환한다")
+    void healthCheckApiReturnsOk() throws Exception {
+        mockMvc.perform(get("/health-check"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"));
+    }
+} 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
#### 문제 배경
- SecurityConfig에서 특정 엔드포인트만 permitAll()로 허용하고, 나머지는 인증이 필요한 상태로 설정되어 있었음.
- 그 결과, 공개되어야 할 /, /health-check 등의 엔드포인트 및 정적 리소스(index.html, 이미지, JS 등) 접근이 차단되어 Render 배포 과정에서 문제가 발생함.

#### 해결 조치
1. SecurityConfig 수정
  다음 경로들을 permitAll() 목록에 추가
    ```
    "/", "/health-check", "/index.html", "/favicon.ico", "/css/**", "/js/**", "/images/**"
    ```
2. IndexController 수정
    컨트롤러의 매핑이 static/index.html보다 우선 적용되어 정적 파일이 무시되는 문제가 있었기 때문에 / 경로에 대한 @RequestMapping을 제거함.

## 링크 (Links)

## 기타 사항 (Etc)
- 최소한의 테스트 항목인 `/health-check` endpoint 테스트 파일을 추가

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 헬스 체크 엔드포인트("/health-check")에 대한 접근이 허용되어 상태 확인이 가능해졌습니다.
  - 통합 테스트가 추가되어 `/health-check` API의 정상 동작을 검증합니다.

- **버그 수정**
  - 루트 URL("/")에 대한 컨트롤러의 명시적 처리가 제거되어, 해당 경로로의 요청이 더 이상 별도의 뷰를 반환하지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->