### PR TITLE
[RING-65] 로그아웃 refresh token을 request header에서 request body로 변경

### DIFF
--- a/backend/src/main/java/com/airing/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/airing/backend/auth/controller/AuthController.java
@@ -1,20 +1,25 @@
 package com.airing.backend.auth.controller;
 
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.airing.backend.auth.Service.AuthService;
+import com.airing.backend.auth.dto.LogoutRequest;
 import com.airing.backend.auth.dto.ResetPasswordRequest;
 import com.airing.backend.auth.dto.TokenReissueRequest;
-import com.airing.backend.auth.jwt.JwtProvider;
 import com.airing.backend.user.dto.UserLoginRequest;
 import com.airing.backend.user.dto.UserLoginResponse;
 import com.airing.backend.user.dto.UserSignupRequest;
-import com.airing.backend.user.repository.UserRepository;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -42,8 +47,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestHeader("Authorization") String refreshTokenHeader) {
-        authService.logout(refreshTokenHeader);
+    public ResponseEntity<?> logout(@RequestBody LogoutRequest request) {
+        authService.logout(request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/backend/src/main/java/com/airing/backend/auth/dto/LogoutRequest.java
+++ b/backend/src/main/java/com/airing/backend/auth/dto/LogoutRequest.java
@@ -1,0 +1,10 @@
+package com.airing.backend.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LogoutRequest {
+    private String refreshToken;
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 일관성을 위한 변경
- Authorization header는 access token만 사용하도록 하고 refresh token은 body로 전달

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 로그아웃 요청 시 리프레시 토큰을 요청 본문으로 전달하도록 변경되었습니다.

- **버그 수정**
	- 토큰 검증 실패 시 더 명확한 오류 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->