### PR TITLE
[RING-66] 로그아웃 refresh token을 request header에서 request body로 변경

### DIFF
--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -37,15 +37,7 @@ export async function reissueToken(
 }
 
 export async function logoutApi(refreshToken: string) {
-  return plainApi.post(
-    '/auth/logout',
-    {},
-    {
-      headers: {
-        Authorization: `Bearer ${refreshToken}`,
-      },
-    },
-  );
+  return plainApi.post('/auth/logout', {refreshToken});
 }
 
 export async function resetPasswordApi(


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- Authorization 헤더 대신 body에 refreshToken 전달하도록 변경

## 링크 (Links)
#36 

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그아웃 요청 시 리프레시 토큰 전달 방식이 변경되어, 로그아웃 기능의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->