### PR TITLE
[RING-73] 로그아웃 및 토큰 재발급 api에서 refresh token을 header에 넣도록 변경

### DIFF
--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -32,12 +32,20 @@ export async function signUpApi(data: SignUpParams): Promise<void> {
 export async function reissueToken(
   refreshToken: string,
 ): Promise<TokenResponse> {
-  const res = await plainApi.post('/auth/reissue', {refreshToken});
+  const res = await plainApi.post('/auth/reissue', undefined, {
+    headers: {
+      Authorization: `Bearer ${refreshToken}`,
+    },
+  });
   return res.data;
 }
 
 export async function logoutApi(refreshToken: string) {
-  return plainApi.post('/auth/logout', {refreshToken});
+  return plainApi.post('/auth/logout', undefined, {
+    headers: {
+      Authorization: `Bearer ${refreshToken}`,
+    },
+  });
 }
 
 export async function resetPasswordApi(


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- refreshToken을 body 대신 Authorization 헤더에 포함하도록 수정
- RFC 6750 (Bearer Token Usage) 표준을 따르도록 개선

![image](https://github.com/user-attachments/assets/630b5be9-71b4-4167-a24a-3c21e9f4ad5a)


## 링크 (Links)
#38 

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 토큰 재발급 및 로그아웃 요청 시, refreshToken이 요청 본문이 아닌 Authorization 헤더를 통해 전달되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->