### PR TITLE
[RING-68] PR title의 Task ID가 branch와 동일한지 검증 추가

### DIFF
--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -70,8 +70,26 @@ jobs:
                   title_regex="^\[RING-[1-9][0-9]*\] .+$"
                   pr_title="${{ github.event.pull_request.title }}"
                   echo "pr_title=$pr_title" >> "$GITHUB_ENV"
+
+                  # Extract RING number from PR title
+                  if [[ $pr_title =~ \[RING-([0-9]+)\] ]]; then
+                    pr_ring_number="${BASH_REMATCH[1]}"
+                    echo "pr_ring_number=$pr_ring_number" >> "$GITHUB_ENV"
+                  fi
+
+                  # Extract RING number from branch name
+                  if [[ $branch_name =~ RING-([0-9]+) ]]; then
+                    branch_ring_number="${BASH_REMATCH[1]}"
+                    echo "branch_ring_number=$branch_ring_number" >> "$GITHUB_ENV"
+                  fi
+
                   if [[ ! $pr_title =~ $title_regex ]]; then
                     echo "is_invalid_title=true" >> "$GITHUB_ENV"
+                  fi
+
+                  # Check if RING numbers match
+                  if [[ "$pr_ring_number" != "$branch_ring_number" ]]; then
+                    echo "is_mismatched_ring_number=true" >> "$GITHUB_ENV"
                   fi
 
             - name: Add comment for invalid PR title
@@ -102,3 +120,33 @@ jobs:
                       }
 
                       core.setFailed("PR Title Convention 위반");
+
+            - name: Add comment for mismatched RING number
+              if: env.is_mismatched_ring_number == 'true'
+              uses: actions/github-script@v7
+              env:
+                  PR_TITLE: ${{ env.pr_title }}
+                  BRANCH_NAME: ${{ env.branch_name }}
+                  PR_RING_NUMBER: ${{ env.pr_ring_number }}
+                  BRANCH_RING_NUMBER: ${{ env.branch_ring_number }}
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const prTitle = process.env.PR_TITLE;
+                      const branchName = process.env.BRANCH_NAME;
+                      const prRingNumber = process.env.PR_RING_NUMBER;
+                      const branchRingNumber = process.env.BRANCH_RING_NUMBER;
+                      const message = "## :warning: RING 번호 불일치\n" +
+                                      "PR 제목의 RING 번호(" + prRingNumber + ")와 브랜치 이름의 RING 번호(" + branchRingNumber + ")가 일치하지 않습니다.\n" +
+                                      "PR 제목과 브랜치 이름의 RING 번호를 동일하게 맞춰주세요.";
+                      const isValidTrigger = process.env.IS_VALID_TRIGGER;
+                      if (isValidTrigger) {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                          body: message
+                        });
+                      }
+
+                      core.setFailed("RING 번호 불일치");


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- PR 제목에서 RING-숫자 형식의 번호를 추출
- 브랜치 이름에서도 동일한 형식으로 RING 번호 추출
- 두 값이 불일치할 경우 경고 댓글을 작성하고 빌드 실패 처리
- 제목 포맷 검증 외에 추가적인 정책 일관성 확보 목적

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [ ] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - PR 제목과 브랜치명에 포함된 RING 번호가 일치하지 않을 경우 자동으로 감지하여 PR에 알림 댓글을 남기고, 워크플로우를 실패 처리하도록 검증 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->