### PR TITLE
[RING-87] 앱 잠금 비밀번호 페이지 추가

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -13,11 +13,13 @@ import {enableScreens} from 'react-native-screens';
 
 import AuthStack from './src/navigation/AuthStack';
 import HomeTabs from './src/navigation/HomeTabs';
+import AppLockScreen from './src/screens/AppLockScreen';
 import SplashScreen from './src/screens/SplashScreen';
 import {useAuthStore} from './src/store/authStore';
 
 export type RootStackParamList = {
   Auth: undefined;
+  AppLock: undefined;
   Home: undefined;
 };
 
@@ -41,7 +43,10 @@ const App = () => {
       <NavigationContainer>
         <Stack.Navigator screenOptions={{headerShown: false}}>
           {isLoggedIn ? (
-            <Stack.Screen name="Home" component={HomeTabs} />
+            <>
+              <Stack.Screen name="AppLock" component={AppLockScreen} />
+              <Stack.Screen name="Home" component={HomeTabs} />
+            </>
           ) : (
             <Stack.Screen name="Auth" component={AuthStack} />
           )}

--- a/frontend/src/assets/icons/ic-emotion-eyes.svg
+++ b/frontend/src/assets/icons/ic-emotion-eyes.svg
@@ -1,0 +1,17 @@
+<svg width="21" height="14" viewBox="0 0 21 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_g_385_2883)">
+<path d="M3.53516 3.1582V10.2635" stroke="white" stroke-width="5" stroke-linecap="round"/>
+<path d="M17.9385 3.1582V10.2635" stroke="white" stroke-width="5" stroke-linecap="round"/>
+</g>
+<defs>
+<filter id="filter0_g_385_2883" x="0.735156" y="0.358203" width="20.0033" height="12.7055" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="10 10" numOctaves="3" seed="514" />
+<feDisplacementMap in="shape" scale="0.60000002384185791" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_385_2883">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/frontend/src/screens/AppLockScreen.tsx
+++ b/frontend/src/screens/AppLockScreen.tsx
@@ -1,0 +1,180 @@
+import {useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import React, {useRef, useState} from 'react';
+import {
+  Dimensions,
+  Keyboard,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+
+import {RootStackParamList} from '../../App';
+import EyesIcon from '../assets/icons/ic-emotion-eyes.svg';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+
+const AppLockScreen = () => {
+  const [password, setPassword] = useState<string>('');
+  const [error, setError] = useState<boolean>(false);
+  const inputRef = useRef<TextInput | null>(null);
+
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList, 'AppLock'>>();
+
+  const correctPassword = '1234'; // 테스트용 비밀번호
+
+  const handlePasswordChange = (text: string) => {
+    setPassword(text);
+    setError(false);
+    if (text.length === 4) {
+      if (text === correctPassword) {
+        setTimeout(() => {
+          setPassword('');
+          setError(false);
+          navigation.replace('Home');
+        }, 500);
+      } else {
+        setError(true);
+        setTimeout(() => {
+          setError(false);
+          setPassword('');
+        }, 500);
+      }
+    }
+  };
+
+  const username = '아이링'; // 테스트용 사용자명
+
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <View style={styles.container}>
+        <View style={styles.titleWrap}>
+          {/* 상단 안내문구 */}
+          <Text style={styles.title}>비밀번호를 입력해주세요</Text>
+          <Text style={styles.subtitle}>
+            이 일기는 {username}님만 볼 수 있어요!
+          </Text>
+        </View>
+
+        {/* 비밀번호 네모 입력칸 */}
+        <TouchableOpacity
+          activeOpacity={1}
+          onPress={() => inputRef.current?.focus()}
+          style={styles.inputBoxWrap}>
+          {[0, 1, 2, 3].map(idx => {
+            let boxStyle = styles.inputBoxInactive;
+            let showEyes = false;
+            if (password.length === 4) {
+              if (error) {
+                boxStyle = styles.inputBoxError;
+                showEyes = true;
+              } else {
+                boxStyle = styles.inputBoxSuccess;
+                showEyes = true;
+              }
+            } else if (password.length > idx) {
+              boxStyle = styles.inputBoxInputting;
+              showEyes = true;
+            }
+            return (
+              <View
+                key={idx}
+                style={[styles.inputBox, boxStyle, styles.inputBoxContent]}>
+                {showEyes && <EyesIcon />}
+              </View>
+            );
+          })}
+          {/* 실제 입력은 숨김 TextInput으로 처리 */}
+          <TextInput
+            ref={inputRef}
+            value={password}
+            onChangeText={handlePasswordChange}
+            keyboardType="number-pad"
+            maxLength={4}
+            style={styles.hiddenInput}
+            autoFocus
+            secureTextEntry
+            caretHidden
+          />
+        </TouchableOpacity>
+      </View>
+    </TouchableWithoutFeedback>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    paddingHorizontal: 32,
+  },
+  titleWrap: {
+    width: '100%',
+    gap: 20,
+    marginTop: SCREEN_HEIGHT * 0.188,
+    marginBottom: 43,
+  },
+  title: {
+    fontSize: 24,
+    letterSpacing: 0.5,
+    fontWeight: '600',
+    fontFamily: 'Pretendard',
+    color: '#0a0a05',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    letterSpacing: 0.3,
+    fontWeight: '500',
+    fontFamily: 'Pretendard',
+    color: 'rgba(0, 0, 0, 0.4)',
+    textAlign: 'center',
+  },
+  inputBoxWrap: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 15,
+    width: '100%',
+    height: 70,
+  },
+  inputBox: {
+    width: 70,
+    height: 70,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    marginHorizontal: 0,
+  },
+  inputBoxInactive: {
+    backgroundColor: '#f4f4f4',
+    borderColor: '#f4f4f4',
+  },
+  inputBoxInputting: {
+    backgroundColor: '#191919',
+    borderColor: '#191919',
+  },
+  inputBoxSuccess: {
+    backgroundColor: '#48C06D',
+    borderColor: '#48C06D',
+  },
+  inputBoxError: {
+    backgroundColor: '#F36A89',
+    borderColor: '#F36A89',
+  },
+  hiddenInput: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    opacity: 0,
+  },
+  inputBoxContent: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppLockScreen;

--- a/frontend/src/screens/AppLockScreen.tsx
+++ b/frontend/src/screens/AppLockScreen.tsx
@@ -47,11 +47,11 @@ const PasswordBox = ({status}: PasswordBoxProps) => {
   );
 };
 
-function getBoxStatus(
+const getBoxStatus = (
   idx: number,
   password: string,
   error: boolean,
-): PasswordBoxStatus {
+): PasswordBoxStatus => {
   if (password.length === PASSWORD_LENGTH) {
     return error ? 'error' : 'success';
   }
@@ -59,7 +59,7 @@ function getBoxStatus(
     return 'inputting';
   }
   return 'inactive';
-}
+};
 
 const AppLockScreen = () => {
   const [password, setPassword] = useState<string>('');


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- HomeTab 이동 전에 앱 잠금 비밀번호 screen이 뜸
  - 비밀번호를 입력해야만 HomeTab으로 이동 가능
- 테스트용 비밀번호 `1234`
- 테스트용 유저이름 `아이링`

<p align="center">
  <img src="https://github.com/user-attachments/assets/f8502d2f-5b3a-4b5b-b763-2979f1611009" alt="Settings Page" width="30%"/>
  <img src="https://github.com/user-attachments/assets/791968dd-b941-4402-b5c1-3b8c568d792b" alt="Reset Password" width="30%"/>
  <img src="https://github.com/user-attachments/assets/df775a8c-803b-4eba-94e2-78cab232975d" alt="Settings Page" width="30%"/>
</p>

- 틀렸을 때
    <img src="https://github.com/user-attachments/assets/2b9d293e-2486-40f9-9f91-75e90d8303dd" alt="Reset Password" width="30%"/>
- 맞았을 때 → HomeTab으로 이동
  <img src="https://github.com/user-attachments/assets/feefcde3-ab96-499f-bc46-a9fa03382cf6" alt="Reset Password" width="30%"/>

## 링크 (Links)

## 기타 사항 (Etc)
지금은 기기 자체 keyboard를 사용했는데 가끔 keyboard가 뜨지 않는 오류가 있어서 일관된 동작을 보장하기 위해 따로 만들어야 할 듯

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 4자리 비밀번호 잠금 화면(AppLockScreen)이 추가되어, 홈 화면 진입 전 비밀번호 입력이 필요합니다.

- **네비게이션 개선**
  - 앱의 네비게이션 흐름이 변경되어, 로그인하지 않은 경우 인증 화면이, 로그인 후에는 잠금 화면과 홈 화면이 순차적으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->