### PR TITLE
[RING-93] chore: AwsS3Config에서 불필요한 @PropertySource 애노테이션 제거

### DIFF
--- a/backend/src/main/java/com/airing/backend/config/AwsS3Config.java
+++ b/backend/src/main/java/com/airing/backend/config/AwsS3Config.java
@@ -15,7 +15,6 @@ import java.net.URI;
 
 @Slf4j
 @Configuration
-@PropertySource("classpath:properties/env.properties")
 public class AwsS3Config {
 
     @Value("${AWS_ACCESS_KEY}")
@@ -43,7 +42,6 @@ public class AwsS3Config {
         return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                .endpointOverride(URI.create("https://s3." + region + ".amazonaws.com")) // 이 줄 추가
                 .build();
     }
 }


### PR DESCRIPTION
- `env.properties` 직접 로드가 아닌 Spring Boot 환경변수 시스템에 통합되었기 때문

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [ ] 마지막 줄에 공백 처리를 하셨나요?
-   [ ] 커밋 단위를 의미 단위로 나눴나요?
-   [ ] 커밋 본문을 작성하셨나요?
-   [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [ ] PR 리뷰 가능한 크기를 유지하셨나요?
-   [ ] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - AWS S3 구성 방식이 개선되어 외부 프로퍼티 파일 및 특정 엔드포인트 설정이 제거되었습니다.  
  - 서비스 이용에는 영향이 없으며, 기존 기능은 동일하게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->