### PR TITLE
[RING-97] 공통 Header component marginBottom prop 추가

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -7,12 +7,13 @@ import IcChevronLeft from '../assets/icons/ic-chevron-left.svg';
 interface HeaderProps {
   title: string;
   onBackPress: () => void;
+  marginBottom?: number;
 }
 
-const Header = ({title, onBackPress}: HeaderProps) => {
+const Header = ({title, onBackPress, marginBottom = 0}: HeaderProps) => {
   const insets = useSafeAreaInsets();
   return (
-    <View style={[styles.header, {marginTop: insets.top}]}>
+    <View style={[styles.header, {marginTop: insets.top, marginBottom}]}>
       <TouchableOpacity style={styles.backBtn} onPress={onBackPress}>
         <IcChevronLeft width={24} height={24} />
       </TouchableOpacity>

--- a/frontend/src/screens/main/call-log/CallLogDetailScreen.tsx
+++ b/frontend/src/screens/main/call-log/CallLogDetailScreen.tsx
@@ -97,16 +97,6 @@ const CallLogDetailScreen = () => {
         title={formatKoreanDate(detail.startedAt)}
         onBackPress={() => navigation.goBack()}
       />
-      {/* <View style={styles.header}>
-        <TouchableOpacity
-          style={styles.backBtn}
-          onPress={() => navigation.goBack()}>
-          <IcChevronLeft width={24} height={24} />
-        </TouchableOpacity>
-        <Text style={[styles.headerDate, styles.textFlexBox]}>
-          {formatKoreanDate(detail.startedAt)}
-        </Text>
-      </View> */}
       <Text style={styles.headerTime}>{formatTime(detail.startedAt)}</Text>
       {/* 대화 내용 */}
       <ScrollView


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 하단 component와의 간격을 조정할 수 있는 marginBottom prop 추가

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Header 컴포넌트에 marginBottom 속성(옵션)이 추가되어 하단 여백을 조정할 수 있습니다.

- **스타일**
  - Header 컴포넌트의 여백 스타일이 개선되었습니다.

- **리팩터**
  - 사용되지 않는 주석 처리된 커스텀 헤더 코드가 CallLogDetailScreen에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->