### PR TITLE
[RING-111] 사용자 정보 조회 API

### DIFF
--- a/backend/src/main/java/com/airing/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/airing/backend/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.airing.backend.user.dto.UserLoginRequest;
 import com.airing.backend.user.dto.UserLoginResponse;
 import com.airing.backend.user.dto.UserSignupRequest;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -26,12 +27,14 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @SecurityRequirements({})
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@Valid @RequestBody UserSignupRequest request) {
         authService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 완료");
     }
 
+    @SecurityRequirements({})
     @PostMapping("/login")
     public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody UserLoginRequest request) {
         UserLoginResponse response = authService.login(request);

--- a/backend/src/main/java/com/airing/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/airing/backend/auth/controller/AuthController.java
@@ -1,8 +1,13 @@
 package com.airing.backend.auth.controller;
 
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,8 +15,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.airing.backend.auth.service.AuthService;
 import com.airing.backend.auth.dto.ResetPasswordRequest;
+import com.airing.backend.auth.security.PrincipalDetails;
+import com.airing.backend.auth.service.AuthService;
 import com.airing.backend.user.dto.UserLoginRequest;
 import com.airing.backend.user.dto.UserLoginResponse;
 import com.airing.backend.user.dto.UserSignupRequest;
@@ -62,5 +68,13 @@ public class AuthController {
     ) {
         authService.resetPassword(authorizationHeader, request);
         return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getMe(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Map<String, String> result = new HashMap<>();
+        result.put("email", principalDetails.getUsername());
+        result.put("username", principalDetails.getNickname());
+        return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/com/airing/backend/auth/security/PrincipalDetails.java
+++ b/backend/src/main/java/com/airing/backend/auth/security/PrincipalDetails.java
@@ -1,13 +1,14 @@
 package com.airing.backend.auth.security;
 
 
-import com.airing.backend.user.entity.User;
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import com.airing.backend.user.entity.User;
 
 /**
  * Spring Security는 /login 으로 오는 POST 요청을 낚아채서 로그인 처리함.
@@ -28,6 +29,10 @@ public class PrincipalDetails implements UserDetails {
 
     public Long getId() {
         return user.getId();
+    }
+    
+    public String getNickname() {
+        return user.getUsername();
     }
 
     // 해당 User의 권한을 리턴함

--- a/backend/src/main/java/com/airing/backend/common/health/HealthCheckController.java
+++ b/backend/src/main/java/com/airing/backend/common/health/HealthCheckController.java
@@ -1,18 +1,20 @@
 package com.airing.backend.common.health;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @Tag(name = "System")
 public class HealthCheckController {
     
+    @SecurityRequirements({})
     @GetMapping("/health-check")
     @Operation(
         summary = "헬스 체크",

--- a/backend/src/main/java/com/airing/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/airing/backend/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import com.airing.backend.auth.jwt.JwtRequestFilter;
 
 import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Configuration
 @EnableWebSecurity // 스프링 시큐리티 필터가 스프링 필터체인에 등록이 된다.
@@ -66,6 +67,14 @@ public class SecurityConfig {
                 .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated())
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((req, res, ex) -> {
+                            res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+                        })
+                        .accessDeniedHandler((req, res, ex) -> {
+                            res.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+                        })
+                )
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/com/airing/backend/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/airing/backend/config/SwaggerConfig.java
@@ -1,12 +1,13 @@
 package com.airing.backend.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
@@ -15,16 +16,15 @@ public class SwaggerConfig {
         String jwt = "JWT";
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
         Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
-                .name(jwt)
+                .name("Authorization")
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
                 .bearerFormat("JWT")
         );
         return new OpenAPI()
-                .components(new Components())
+                .components(components)
                 .info(apiInfo())
-                .addSecurityItem(securityRequirement)
-                .components(components);
+                .addSecurityItem(securityRequirement);
     }
     private Info apiInfo() {
         return new Info()

--- a/backend/src/main/java/com/airing/backend/user/entity/User.java
+++ b/backend/src/main/java/com/airing/backend/user/entity/User.java
@@ -1,15 +1,22 @@
 package com.airing.backend.user.entity;
 
-import com.airing.backend.diary.entity.Diary;
-import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-import org.hibernate.annotations.CreationTimestamp;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.airing.backend.diary.entity.Diary;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
 
 @Entity

--- a/backend/src/main/java/com/airing/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/airing/backend/user/repository/UserRepository.java
@@ -1,12 +1,11 @@
 package com.airing.backend.user.repository;
 
-import com.airing.backend.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 
-@Repository // 생략 가능
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.airing.backend.user.entity.User;
+
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,12 +1,11 @@
 spring.application.name=backend
-server.port=8081
+server.port=8080
 server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.enabled=true
 server.servlet.encoding.force=true
 
 # jwt
 jwt.access-token.expiration=3600000
-# refresh \uD1A0\uD070 0 \uB450 \uAC1C \uB354 \uBD99\uC784
 jwt.refresh-token.expiration=120960000000
 jwt.secretKey=${JWT_SECRET_KEY:UDlidFpYVzduTTZxQTJlWSFwVnJKNCR6R3VLZkhjWHElMUx3RDhSYk4wb0VqVGdWQEttWXFYM3NVelFmNUxyQg==}
 
@@ -17,18 +16,18 @@ spring.cloud.aws.stack.auto=false
 spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 spring.cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 
-# \uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC124\uC815
+# 데이터베이스 설정
 spring.datasource.url=${DATABASE_URL:jdbc:postgresql://localhost:5432/airing}
 spring.datasource.username=${DATABASE_USERNAME:postgres}
 spring.datasource.password=${DATABASE_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# JPA \uC124\uC815
+# JPA 설정
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
-# \uB85C\uAE45 \uC124\uC815
+# 로깅 설정
 logging.level.org.hibernate.SQL=${HIBERNATE_SQL_LEVEL:DEBUG}
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=${HIBERNATE_BINDER_LEVEL:TRACE}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- AuthenticationPrincipal 기반 인증/인가로 사용자 정보 조회 API 구현
- Swagger 설정 업데이트
- 서버 port 번호를 8080으로 변경

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 인증된 사용자의 이메일과 닉네임을 반환하는 `/me` 엔드포인트가 추가되었습니다.

- **버그 수정**
    - 인증 실패 시 401 Unauthorized, 권한 부족 시 403 Forbidden 상태 코드와 메시지가 반환되도록 보안 예외 처리가 개선되었습니다.
    - OpenAPI 문서에서 `/signup`, `/login`, `/health` 엔드포인트가 인증 없이 접근 가능함이 명확하게 표시됩니다.
    - Swagger 보안 스키마 설정이 올바르게 적용되어 JWT 인증이 정상적으로 문서화됩니다.

- **환경 설정**
    - 서버 포트가 8081에서 8080으로 변경되었습니다.

- **스타일**
    - 여러 파일에서 import 구문이 정리되어 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->