### PR TITLE
[RING-122] 앱 잠금 비밀번호 입력 키패드에 전체 삭제 기능 추가

### DIFF
--- a/frontend/src/components/password/NumPad.tsx
+++ b/frontend/src/components/password/NumPad.tsx
@@ -6,15 +6,16 @@ import BackspaceIcon from '../../assets/icons/ic-backspace.svg';
 interface NumPadProps {
   onPress: (num: string) => void;
   onBackspace: () => void;
+  onClear?: () => void;
   disabled?: boolean;
 }
 
-const NumPad = ({onPress, onBackspace, disabled}: NumPadProps) => {
+const NumPad = ({onPress, onBackspace, onClear, disabled}: NumPadProps) => {
   const numbers = [
     ['1', '2', '3'],
     ['4', '5', '6'],
     ['7', '8', '9'],
-    ['', '0', '<'],
+    ['<', '0', 'CLEAR'],
   ];
 
   return (
@@ -33,6 +34,17 @@ const NumPad = ({onPress, onBackspace, disabled}: NumPadProps) => {
                   onPress={onBackspace}
                   disabled={disabled}>
                   <BackspaceIcon width={32} height={32} color={'#888'} />
+                </TouchableOpacity>
+              );
+            }
+            if (item === 'CLEAR') {
+              return (
+                <TouchableOpacity
+                  key={colIdx}
+                  style={styles.numpadButton}
+                  onPress={onClear}
+                  disabled={disabled}>
+                  <Text style={styles.numpadButtonTextClear}>{item}</Text>
                 </TouchableOpacity>
               );
             }
@@ -75,6 +87,12 @@ const styles = StyleSheet.create({
     fontSize: 28,
     color: '#0a0a05',
     fontWeight: '500',
+    textAlign: 'center',
+  },
+  numpadButtonTextClear: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#292929',
     textAlign: 'center',
   },
 });

--- a/frontend/src/screens/AppLockScreen.tsx
+++ b/frontend/src/screens/AppLockScreen.tsx
@@ -64,6 +64,7 @@ const AppLockScreen = () => {
       <NumPad
         onPress={handleNumPress}
         onBackspace={handleBackspace}
+        onClear={() => setPassword('')}
         disabled={password.length === PASSWORD_LENGTH}
       />
     </AppScreen>

--- a/frontend/src/screens/main/settings/SetAppLockPasswordScreen.tsx
+++ b/frontend/src/screens/main/settings/SetAppLockPasswordScreen.tsx
@@ -22,6 +22,11 @@ const SetAppLockPasswordScreen = () => {
   const [isError, setIsError] = useState<boolean>(false);
   const [errorMsg, setErrorMsg] = useState<string>('');
 
+  const resetError = () => {
+    setIsError(false);
+    setErrorMsg('');
+  };
+
   const handleNumPress = (num: string) => {
     if (step === 'new') {
       if (newPassword.length >= PASSWORD_LENGTH) {
@@ -29,8 +34,7 @@ const SetAppLockPasswordScreen = () => {
       }
       const next = newPassword + num;
       setNewPassword(next);
-      setIsError(false);
-      setErrorMsg('');
+      resetError();
       if (next.length === PASSWORD_LENGTH) {
         setTimeout(() => setStep('confirm'), 500);
       }
@@ -40,8 +44,7 @@ const SetAppLockPasswordScreen = () => {
       }
       const next = confirmPassword + num;
       setConfirmPassword(next);
-      setIsError(false);
-      setErrorMsg('');
+      resetError();
       if (next.length === PASSWORD_LENGTH) {
         if (next === newPassword) {
           setAppLockPassword(next)
@@ -66,8 +69,7 @@ const SetAppLockPasswordScreen = () => {
             setNewPassword('');
             setConfirmPassword('');
             setStep('new');
-            setIsError(false);
-            setErrorMsg('');
+            resetError();
           }, 1000);
         }
       }
@@ -80,16 +82,22 @@ const SetAppLockPasswordScreen = () => {
         return;
       }
       setNewPassword(newPassword.slice(0, -1));
-      setIsError(false);
-      setErrorMsg('');
     } else {
       if (confirmPassword.length === 0) {
         return;
       }
       setConfirmPassword(confirmPassword.slice(0, -1));
-      setIsError(false);
-      setErrorMsg('');
     }
+    resetError();
+  };
+
+  const handleClear = () => {
+    if (step === 'new') {
+      setNewPassword('');
+    } else {
+      setConfirmPassword('');
+    }
+    resetError();
   };
 
   return (
@@ -121,6 +129,7 @@ const SetAppLockPasswordScreen = () => {
       <NumPad
         onPress={handleNumPress}
         onBackspace={handleBackspace}
+        onClear={handleClear}
         disabled={
           step === 'new'
             ? newPassword.length === PASSWORD_LENGTH


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- NumPad에 CLEAR 버튼 추가 및 스타일 정의
- AppLockScreen, SetAppLockPasswordScreen에서 CLEAR 버튼 핸들링 로직 구현

<img src="https://github.com/user-attachments/assets/ada2d4aa-5f54-4b65-8e17-fb3e6fe2a848" alt="Password" width="40%"/>

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 숫자 키패드에 "CLEAR" 버튼이 추가되어, 비밀번호 입력을 한 번에 모두 지울 수 있습니다.

- **버그 수정**
  - 비밀번호 입력 중 오류 메시지가 더 일관되게 초기화되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->