### PR TITLE
[RING-130] 알람 초기 등록 로직을 zustand rehydration 후 처리하도록 수정

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -34,10 +34,8 @@ import SelectVibrateScreen from './src/screens/main/settings/SelectVibrateScreen
 import SelectVoiceScreen from './src/screens/main/settings/SelectVoiceScreen';
 import SetAppLockPasswordScreen from './src/screens/main/settings/SetAppLockPasswordScreen';
 import SplashScreen from './src/screens/SplashScreen';
-import {useAiCallSettingsStore} from './src/store/aiCallSettingsStore';
 import {useAppLockStore} from './src/store/appLockStore';
 import {useAuthStore} from './src/store/authStore';
-import {updateScheduledAlarms} from './src/utils/alarmManager';
 
 export type RootStackParamList = {
   Auth: undefined;
@@ -111,21 +109,9 @@ const App = () => {
 
   const navigationRef = useRef<NavigationContainerRef<any>>(null);
 
-  const {isAlarmRegistered, setAlarmRegistered} = useAiCallSettingsStore();
-
   useNotificationPermissions();
   useNotifeeEvents(navigationRef);
   useVibrationChannels();
-
-  useEffect(() => {
-    async function registerAlarmOnce() {
-      if (!isAlarmRegistered) {
-        await updateScheduledAlarms();
-        setAlarmRegistered(true);
-      }
-    }
-    registerAlarmOnce();
-  }, [isAlarmRegistered, setAlarmRegistered]);
 
   useEffect(() => {
     checkAuth();

--- a/frontend/src/store/aiCallSettingsStore.ts
+++ b/frontend/src/store/aiCallSettingsStore.ts
@@ -90,9 +90,14 @@ export const useAiCallSettingsStore = create<AiCallSettingsState>()(
       }),
       onRehydrateStorage: () => async state => {
         if (!state?.isAlarmRegistered) {
-          console.log('registerAlarmOnce');
-          await updateScheduledAlarms();
           state?.setAlarmRegistered(true);
+          try {
+            console.log('[Alarm] register once after rehydrate');
+            await updateScheduledAlarms();
+          } catch (err) {
+            console.error('[Alarm] failed to register scheduled alarms', err);
+            state?.setAlarmRegistered(false); // 롤백 -> 다음 부팅 때 재시도
+          }
         }
       },
     },

--- a/frontend/src/store/aiCallSettingsStore.ts
+++ b/frontend/src/store/aiCallSettingsStore.ts
@@ -2,6 +2,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {create} from 'zustand';
 import {createJSONStorage, persist} from 'zustand/middleware';
 
+import {updateScheduledAlarms} from '../utils/alarmManager';
+
 // Vibrate 옵션: label + 실제 패턴
 export const VIBRATE_LIST = [
   {label: 'Basic', pattern: [1, 500, 200, 500]},
@@ -86,6 +88,13 @@ export const useAiCallSettingsStore = create<AiCallSettingsState>()(
 
         isAlarmRegistered: state.isAlarmRegistered,
       }),
+      onRehydrateStorage: () => async state => {
+        if (!state?.isAlarmRegistered) {
+          console.log('registerAlarmOnce');
+          await updateScheduledAlarms();
+          state?.setAlarmRegistered(true);
+        }
+      },
     },
   ),
 );


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
기존에는 스토어 복원 전 값이 읽혀 앱이 매번 실행할 때마다 알람이
등록되는 문제가 있었습니다. 이를 해결하기 위해 스토어 복원 후에 값을
읽고 알람 등록 로직을 실행하도록 수정했습니다. 이제 앱을 처음 실행했을
때 한번만 기본 알람이 등록되어 효율적으로 처리됩니다.
- zustand의 `onRehydrateStorage` listener function을 활용해 스토어 복원 직후 알람 등록 실행
- App 컴포넌트에서 불필요한 상태 구독 및 효과 제거
- 앱 부팅 시점에 알람 등록을 안전하고 일관되게 수행

## 링크 (Links)
[알람 등록이 앱 실행 시마다 발생하는 문제](https://do0ori.notion.site/20f8ad358684807c9389dfe2f698c824?pvs=74)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 앱 실행 시 알람이 중복 등록되는 문제를 방지하도록 알람 등록 로직이 개선되었습니다.  
- **기타**
  - 내부 저장소 복원 시 알람 상태가 자동으로 동기화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->