### PR TITLE
[RING-134] 통화 준비 API 추가

### DIFF
--- a/backend/src/main/java/com/airing/backend/callLog/controller/CallLogController.java
+++ b/backend/src/main/java/com/airing/backend/callLog/controller/CallLogController.java
@@ -1,22 +1,30 @@
 package com.airing.backend.callLog.controller;
 
+import java.time.YearMonth;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
 import com.airing.backend.callLog.dto.CallLogDetailResponse;
 import com.airing.backend.callLog.dto.CallLogEventRequest;
 import com.airing.backend.callLog.dto.CallLogLatestResponse;
 import com.airing.backend.callLog.dto.CallLogMonthlyResponse;
 import com.airing.backend.callLog.service.CallLogService;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.time.YearMonth;
-import java.util.List;
 
 @RestController
-@RequestMapping("/call_logs")
+@RequestMapping("/api/call_logs")
 @RequiredArgsConstructor
 public class CallLogController {
 

--- a/backend/src/main/java/com/airing/backend/callLog/dto/CallLogEventRequest.java
+++ b/backend/src/main/java/com/airing/backend/callLog/dto/CallLogEventRequest.java
@@ -1,8 +1,15 @@
 package com.airing.backend.callLog.dto;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
 import lombok.Getter;
 import lombok.Setter;
-import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
 
 @Getter
 @Setter
@@ -14,5 +21,15 @@ public class CallLogEventRequest {
 
     private OffsetDateTime startedAt;
 
-    private String rawTranscript;
+    private List<Message> rawTranscript;
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Message {
+        private String from;
+        private String message;
+    }
 }

--- a/backend/src/main/java/com/airing/backend/callLog/entity/CallLog.java
+++ b/backend/src/main/java/com/airing/backend/callLog/entity/CallLog.java
@@ -1,12 +1,22 @@
 package com.airing.backend.callLog.entity;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import com.airing.backend.callLog.dto.CallLogEventRequest.Message;
+import com.airing.backend.common.converter.JsonConverter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.*;
-
-import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -28,5 +38,7 @@ public class CallLog {
 
     private int duration;
 
-    private String rawTranscript;
+    @Column(columnDefinition = "jsonb")
+    @Convert(converter = JsonConverter.class)
+    private List<Message> rawTranscript;
 }

--- a/backend/src/main/java/com/airing/backend/callSummary/controller/CallSummaryController.java
+++ b/backend/src/main/java/com/airing/backend/callSummary/controller/CallSummaryController.java
@@ -1,16 +1,23 @@
 package com.airing.backend.callSummary.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.airing.backend.callSummary.dto.CallSummaryRequest;
 import com.airing.backend.callSummary.dto.CallSummaryResponse;
 import com.airing.backend.callSummary.service.CallSummaryService;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/call_summary")
+@RequestMapping("/api/call_summary")
 @RequiredArgsConstructor
 public class CallSummaryController {
 

--- a/backend/src/main/java/com/airing/backend/common/converter/JsonConverter.java
+++ b/backend/src/main/java/com/airing/backend/common/converter/JsonConverter.java
@@ -1,0 +1,38 @@
+package com.airing.backend.common.converter;
+
+import java.util.List;
+
+import com.airing.backend.callLog.dto.CallLogEventRequest.Message;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class JsonConverter implements AttributeConverter<List<Message>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Message> messages) {
+        try {
+            return objectMapper.writeValueAsString(messages);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting list to JSON", e);
+        }
+    }
+
+    @Override
+    public List<Message> convertToEntityAttribute(String dbData) {
+        try {
+            if (dbData == null) {
+                return null;
+            }
+            return objectMapper.readValue(dbData, new TypeReference<List<Message>>() {});
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting JSON to list", e);
+        }
+    }
+} 

--- a/backend/src/main/java/com/airing/backend/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/airing/backend/config/RestTemplateConfig.java
@@ -1,5 +1,8 @@
 package com.airing.backend.config;
 
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -8,7 +11,10 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfig {
 
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+            .connectTimeout(Duration.ofSeconds(3))
+            .readTimeout(Duration.ofSeconds(5))
+            .build();
     }
 } 

--- a/backend/src/main/java/com/airing/backend/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/airing/backend/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.airing.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+} 

--- a/backend/src/main/java/com/airing/backend/conversations/controller/ConversationController.java
+++ b/backend/src/main/java/com/airing/backend/conversations/controller/ConversationController.java
@@ -1,0 +1,28 @@
+package com.airing.backend.conversations.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.airing.backend.conversations.dto.ConversationInitRequest;
+import com.airing.backend.conversations.dto.ConversationInitResponse;
+import com.airing.backend.conversations.service.ConversationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/conversations")
+@RequiredArgsConstructor
+public class ConversationController {
+
+    private final ConversationService conversationService;
+
+    @PostMapping("/init")
+    public ConversationInitResponse initConversation(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ConversationInitRequest request) {
+        return conversationService.initConversation(userId, request);
+    }
+} 

--- a/backend/src/main/java/com/airing/backend/conversations/dto/ConversationInitRequest.java
+++ b/backend/src/main/java/com/airing/backend/conversations/dto/ConversationInitRequest.java
@@ -1,0 +1,13 @@
+package com.airing.backend.conversations.dto;
+
+import java.time.OffsetDateTime;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ConversationInitRequest {
+    private OffsetDateTime startedAt;
+    private String callType;
+} 

--- a/backend/src/main/java/com/airing/backend/conversations/dto/ConversationInitResponse.java
+++ b/backend/src/main/java/com/airing/backend/conversations/dto/ConversationInitResponse.java
@@ -1,0 +1,11 @@
+package com.airing.backend.conversations.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConversationInitResponse {
+    private String ephemeralToken;
+    private Long conversationId;
+} 

--- a/backend/src/main/java/com/airing/backend/conversations/service/ConversationService.java
+++ b/backend/src/main/java/com/airing/backend/conversations/service/ConversationService.java
@@ -1,0 +1,48 @@
+package com.airing.backend.conversations.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.airing.backend.callLog.entity.CallLog;
+import com.airing.backend.callLog.repository.CallLogRepository;
+import com.airing.backend.conversations.dto.ConversationInitRequest;
+import com.airing.backend.conversations.dto.ConversationInitResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ConversationService {
+
+    private final CallLogRepository callLogRepository;
+    private final RestTemplate restTemplate;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    public ConversationInitResponse initConversation(Long userId, ConversationInitRequest request) {
+        // 1. Create CallLog entry
+        CallLog callLog = CallLog.builder()
+                .userId(userId)
+                .startedAt(request.getStartedAt())
+                .callType(request.getCallType())
+                .build();
+        
+        CallLog savedCallLog = callLogRepository.save(callLog);
+
+        // 2. Get ephemeral token from AI server
+        String ephemeralToken = restTemplate.postForObject(
+                aiServerUrl + "/api/auth/ephemeral-token",
+                null,
+                EphemeralTokenResponse.class
+        ).ephemeralToken();
+
+        return ConversationInitResponse.builder()
+                .conversationId(savedCallLog.getId())
+                .ephemeralToken(ephemeralToken)
+                .build();
+    }
+
+    private record EphemeralTokenResponse(String ephemeralToken) {}
+} 

--- a/backend/src/main/java/com/airing/backend/image/controller/ImageController.java
+++ b/backend/src/main/java/com/airing/backend/image/controller/ImageController.java
@@ -1,19 +1,24 @@
 package com.airing.backend.image.controller;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.airing.backend.auth.jwt.JwtProvider;
 import com.airing.backend.image.dto.PresignedUrlResponse;
 import com.airing.backend.image.service.ImageService;
-import com.airing.backend.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/images")
+@RequestMapping("/api/images")
 @RequiredArgsConstructor
 public class ImageController {
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,18 +16,21 @@ spring.cloud.aws.stack.auto=false
 spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 spring.cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 
-# \uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC124\uC815
+# AI server
+ai.server.url=${AI_SERVER_URL:http://localhost:8000}
+
+# 데이터베이스 설정
 spring.datasource.url=${DATABASE_URL:jdbc:postgresql://localhost:5432/airing}
 spring.datasource.username=${DATABASE_USERNAME:postgres}
 spring.datasource.password=${DATABASE_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# JPA \uC124\uC815
+# JPA 설정
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
-# \uB85C\uAE45 \uC124\uC815
+# 로깅 설정
 logging.level.org.hibernate.SQL=${HIBERNATE_SQL_LEVEL:DEBUG}
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=${HIBERNATE_BINDER_LEVEL:TRACE}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- callLog에서 `rawTranscript` column의 data type을 `jsonb`로 수정
- POST `/api/conversations/init` 구현
- api 일관성을 위해 prefix `/api`가 누락된 controller 수정
- local 테스트 완료

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 대화 초기화를 위한 새로운 API 엔드포인트(`/api/conversations/init`)가 추가되었습니다. 대화 시작 시 임시 토큰과 대화 ID를 반환합니다.
  - AI 서버 URL 환경설정이 추가되어 외부 AI 서버와 연동이 가능해졌습니다.
  - HTTP 클라이언트(RestTemplate)의 연결 및 읽기 타임아웃 설정이 추가되었습니다.

- **변경사항**
  - 통화 로그, 통화 요약, 이미지 관련 API 경로가 `/api/`로 통일되었습니다.
  - 통화 로그의 대화 기록(rawTranscript)이 문자열에서 메시지 목록(List) 형태로 저장 및 제공됩니다.
  - 통화 로그 조회 시 대화 기록 처리 방식이 개선되어 JSON 파싱 과정이 간소화되었습니다.

- **버그 수정**
  - 없음

- **기타**
  - 내부 데이터 구조에 Lombok 어노테이션이 추가되어 코드 간결성이 향상되었습니다.
  - 데이터베이스에 대화 기록을 JSONB 형식으로 저장하도록 변환 로직이 추가되었습니다.
  - 코드 내 불필요한 와일드카드 임포트가 정리되고 명시적 임포트로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->