### PR TITLE
[RING-144] PR 라벨러 validator 워크플로우에 revert 브랜치 무시 조건 추가

### DIFF
--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -3,6 +3,8 @@ name: Labeler and Validator
 on:
     pull_request:
         types: [opened, edited]
+        branches-ignore:
+            - "revert-*"
 
 jobs:
     label_and_validate:


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
revert-* 브랜치에서 생성된 PR은 자동 라벨링과 유효성 검사에서 제외되도록
GitHub Actions 워크플로우에 branches-ignore 조건을 추가함

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [x] 마지막 줄에 공백 처리를 하셨나요?
-   [x] 커밋 단위를 의미 단위로 나눴나요?
-   [x] 커밋 본문을 작성하셨나요?
-   [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [x] PR 리뷰 가능한 크기를 유지하셨나요?
-   [x] CI 파이프라인이 통과가 되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - "revert-"로 시작하는 브랜치에서는 PR 라벨러 및 검증 워크플로우가 실행되지 않도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->