### PR TITLE
[RING-149] revert- 브랜치에서 PR 라벨러 건너뛰기

### DIFF
--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -3,11 +3,10 @@ name: Labeler and Validator
 on:
     pull_request:
         types: [opened, edited]
-        branches-ignore:
-            - "revert-*"
 
 jobs:
     label_and_validate:
+        if: ${{ !startsWith(github.event.pull_request.head.ref, 'revert-') }}
         permissions:
             contents: read
             pull-requests: write
@@ -26,10 +25,6 @@ jobs:
               run: |
                   branch_name=$(echo "${{ github.event.pull_request.head.ref }}")
                   echo "branch_name=$branch_name" >> "$GITHUB_ENV"
-
-                  if [[ $branch_name =~ ^revert ]]; then
-                    exit 0
-                  fi
 
                   if [[ ! $branch_name =~ ^(frontend|backend|infra|ai)\/RING-[1-9][0-9]*$ ]]; then
                     echo "is_invalid_branch_name=true" >> "$GITHUB_ENV"


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- pull_request 트리거의 branches-ignore 설정 제거(source branch가 아닌 target branch에만 적용되어 효과 없음)
- label_and_validate 잡에 `if: ${{ !startsWith(github.event.pull_request.head.ref, 'revert-') }}` 조건 추가 → 브랜치명이 `revert-`로 시작할 때 워크플로우 실행을 건너뜀


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)

-   [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
-   [ ] 마지막 줄에 공백 처리를 하셨나요?
-   [ ] 커밋 단위를 의미 단위로 나눴나요?
-   [ ] 커밋 본문을 작성하셨나요?
-   [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
-   [ ] PR 리뷰 가능한 크기를 유지하셨나요?
-   [ ] CI 파이프라인이 통과가 되었나요?
